### PR TITLE
MAJOR: removing fetch repos script because it's now in the base conta…

### DIFF
--- a/fetch-repos.sh
+++ b/fetch-repos.sh
@@ -1,7 +1,0 @@
-#https://stackoverflow.com/a/68770988/4620962
-
-gh repo list GlueOps --limit 1000 | while read -r repo _; do
-  gh repo clone "$repo" "$repo" -- --depth=1 --recurse-submodules || {
-    git -C $repo pull
-  } &
-done


### PR DESCRIPTION
MAJOR: removing fetch repos script because it's now in the base container image. Just use glueops-fetch-repos and it's already in your shell PATH