### PR TITLE
feat: adding v0.46.0

### DIFF
--- a/.devcontainer/v0.46.0/devcontainer.json
+++ b/.devcontainer/v0.46.0/devcontainer.json
@@ -1,0 +1,15 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/ubuntu
+{
+	"name": "v0.46.0",
+	"image": "ghcr.io/glueops/codespaces:v0.46.0",
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--privileged", "--init", "--device=/dev/net/tun" ],
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind", "source=/var/run/tailscale/tailscaled.sock,target=/var/run/tailscale/tailscaled.sock,type=bind" ],
+	"overrideCommand": false,
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"customizations": {
+		"codespaces": {	}
+	  }
+}


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a new devcontainer configuration file for version v0.46.0.
- Configured Docker image, run arguments, and mounts.
- Set `remoteUser` to `vscode` and included basic customizations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devcontainer.json</strong><dd><code>Add devcontainer configuration for v0.46.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/v0.46.0/devcontainer.json

<li>Added new devcontainer configuration file for version v0.46.0.<br> <li> Set Docker image to <code>ghcr.io/glueops/codespaces:v0.46.0</code>.<br> <li> Configured run arguments and mounts for Docker.<br> <li> Set <code>remoteUser</code> to <code>vscode</code> and added basic customizations.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/glueops/pull/45/files#diff-7af503d3cf1b34879bb27f987075d8795062201d0560b762097ad0c2a215643e">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

